### PR TITLE
Add SP_COOKIE_NAME variable and update Goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,86 +1,94 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
+
 builds:
-- binary: '{{ .ProjectName }}'
-  env:
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X beryju.io/{{ .ProjectName }}/cmd.Version={{.Version}}'
-  targets:
-    - linux_arm_6
-    - linux_arm_7
-    - linux_arm64
-    - linux_amd64
-    - darwin_arm64
-    - darwin_amd64
-    - freebsd_arm64
-    - freebsd_amd64
-    - windows_arm64
-    - windows_amd64
+  - binary: '{{ .ProjectName }}'
+    env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X beryju.io/{{ .ProjectName }}/cmd.Version={{.Version}}'
+    targets:
+      - linux_arm_6
+      - linux_arm_7
+      - linux_arm64
+      - linux_amd64
+      - darwin_arm64
+      - darwin_amd64
+      - freebsd_arm64
+      - freebsd_amd64
+      - windows_arm64
+      - windows_amd64
+
 dockers:
-- image_templates:
-  - "ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-amd64"
-  use: buildx
-  goarch: amd64
-  build_flag_templates:
-  - "--platform=linux/amd64"
-- image_templates:
-  - "ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-arm64v8"
-  use: buildx
-  goarch: arm64
-  build_flag_templates:
-  - "--platform=linux/arm64/v8"
-- image_templates:
-  - "ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv7"
-  use: buildx
-  goarch: arm
-  goarm: "7"
-  build_flag_templates:
-  - "--platform=linux/arm/v7"
-- image_templates:
-  - "ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv6"
-  use: buildx
-  goarch: arm
-  goarm: "6"
-  build_flag_templates:
-  - "--platform=linux/arm/v6"
+  - image_templates:
+      - "ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-amd64"
+    use: buildx
+    goarch: amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+    use: buildx
+    goarch: arm64
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+  - image_templates:
+      - "ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv7"
+    use: buildx
+    goarch: arm
+    goarm: "7"
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+  - image_templates:
+      - "ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv6"
+    use: buildx
+    goarch: arm
+    goarm: "6"
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+
 docker_manifests:
-- name_template: ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}
-  image_templates:
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-amd64
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-arm64v8
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv7
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv6
-- name_template: ghcr.io/beryju/{{ .ProjectName }}:v{{ .Major }}
-  image_templates:
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-amd64
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-arm64v8
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv7
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv6
-- name_template: ghcr.io/beryju/{{ .ProjectName }}:latest
-  image_templates:
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-amd64
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-arm64v8
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv7
-  - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv6
+  - name_template: ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}
+    image_templates:
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-arm64v8
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv7
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv6
+  - name_template: ghcr.io/beryju/{{ .ProjectName }}:v{{ .Major }}
+    image_templates:
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-arm64v8
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv7
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv6
+  - name_template: ghcr.io/beryju/{{ .ProjectName }}:latest
+    image_templates:
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-arm64v8
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv7
+      - ghcr.io/beryju/{{ .ProjectName }}:{{ .Version }}-armv6
+
 archives:
-- id: raw
-  format: binary
-  name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}'
-- id: tar
-  format: tar.gz
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}'
+  - id: raw
+    format: binary
+    name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}'
+  - id: tar
+    format: tar.gz
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}'
+
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
+
 brews:
   - ids:
       - raw
-    tap:
+    repository:
       owner: beryju
       name: homebrew-tap
     commit_author:
@@ -88,4 +96,3 @@ brews:
       email: goreleaser@beryju.org
     homepage: 'https://github.com/beryju/{{ .ProjectName }}'
     description: 'Small, SAML ServiceProvider for testing and debugging'
-    folder: Formula

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This tool is full configured using environment variables.
 - `SP_ROOT_URL`: Root URL you're using to access the SP. Defaults to `http://localhost:9009`.
 - `SP_ENTITY_ID`: SAML EntityID, defaults to `saml-test-sp`.
 - `SP_METADATA_URL`: Optional URL that metadata is fetched from. The metadata is fetched on the first request to `/`.
-- `SP_COOKIE_NAME`: Custom name for the session cookie. Defaults to token. Use this to avoid cookie name conflicts with other applications.
+- `SP_COOKIE_NAME`: Custom name for the session cookie. Defaults to `token`. Use this to avoid cookie name conflicts with other applications.
 ---
 - `SP_SSO_URL`: If the metadata URL is not configured, use these options to configure it manually.
 - `SP_SSO_BINDING`: Binding Type used for the IdP, defaults to POST. Allowed values: `urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST` and `urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect`

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ This tool is full configured using environment variables.
 
 - `SP_BIND`: Which address and port to bind to. Defaults to `0.0.0.0:9009`.
 - `SP_ROOT_URL`: Root URL you're using to access the SP. Defaults to `http://localhost:9009`.
-- `SP_ENTITY_ID`: SAML EntityID, defaults to `saml-test-sp`
-- `SP_METADATA_URL`: Optional URL that metadata is fetched from. The metadata is fetched on the first request to `/`
+- `SP_ENTITY_ID`: SAML EntityID, defaults to `saml-test-sp`.
+- `SP_METADATA_URL`: Optional URL that metadata is fetched from. The metadata is fetched on the first request to `/`.
+- `SP_COOKIE_NAME`: Custom name for the session cookie. Defaults to token. Use this to avoid cookie name conflicts with other applications.
 ---
 - `SP_SSO_URL`: If the metadata URL is not configured, use these options to configure it manually.
 - `SP_SSO_BINDING`: Binding Type used for the IdP, defaults to POST. Allowed values: `urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST` and `urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect`

--- a/pkg/helpers/config.go
+++ b/pkg/helpers/config.go
@@ -25,6 +25,7 @@ func Env(key string, fallback string) string {
 func LoadConfig() samlsp.Options {
 	samlOptions := samlsp.Options{
 		AllowIDPInitiated: true,
+		CookieName: Env("SP_COOKIE_NAME", "token"),
 	}
 
 	samlOptions.EntityID = Env("SP_ENTITY_ID", "saml-test-sp")


### PR DESCRIPTION
This PR adds the `SP_COOKIE_NAME` environment variable to allow customizing the cookie name used by the Service Provider. By default, it uses the generic name token, which is commonly used by other libraries such as [tymondesigns/jwt-auth](https://github.com/tymondesigns/jwt-auth). This can cause conflicts when multiple libraries run under the same domain.

Adding `SP_COOKIE_NAME` helps avoid such naming collisions and improves compatibility in complex projects.

Additionally, the `.goreleaser.yml` config was updated to fix incompatibilities with the current Goreleaser version.

I would be very grateful if this PR could be merged and released soon, as we need this feature in our project.